### PR TITLE
enabled tab view and made it main window

### DIFF
--- a/livfit/livfit/Core/ MainTab/MainTabView.swift
+++ b/livfit/livfit/Core/ MainTab/MainTabView.swift
@@ -8,41 +8,28 @@
 import SwiftUI
 
 struct MainTabView: View {
-    @State private var SelectedIndex = 0
-     
+    
     var body: some View {
-        TabView(selection: $SelectedIndex) {
+        TabView() {
             FeedView()
-            onTapGesture {
-                self.SelectedIndex = 0
-            }
             .tabItem {
                 Image(systemName: "house")
-            }.tag(0)
+            }
             
             ExploreView()
-            onTapGesture {
-                self.SelectedIndex = 1
-            }
             .tabItem {
                 Image(systemName: "magnifyingglass")
-            }.tag(1)
+            }
             
             NotificationsView()
-            onTapGesture {
-                self.SelectedIndex = 2
-            }
             .tabItem {
                 Image(systemName: "bell")
-            }.tag(2)
+            }
             
             BookmarksView()
-            onTapGesture {
-                self.SelectedIndex = 3
-            }
             .tabItem {
                 Image(systemName: "bookmark")
-            }.tag(3)
+            }
         } 
     }
 }

--- a/livfit/livfit/livfitApp.swift
+++ b/livfit/livfit/livfitApp.swift
@@ -11,7 +11,14 @@ import SwiftUI
 struct livfitApp: App {
     var body: some Scene {
         WindowGroup {
-            FeedView()
+            MainTabView()
         }
+    }
+}
+
+
+struct livfitApp_Previews: PreviewProvider {
+    static var previews: some View {
+        MainTabView()
     }
 }


### PR DESCRIPTION
Looks great so far! I made a few changes. First, in livfitApp.swift I changed the window to display to the MainTabView view.  Second, I think you over engineered the Tabview.  It will take care of remembering which tab is selected.  All you need to do it tell it which view to display when a tab bar button is selected. 

Btw you don't have to merge it into main.  You can make the changes yourself so you can understand what's going on if you want to. 